### PR TITLE
panning the items left and right and make the map sticky

### DIFF
--- a/app/views/flats/index.html.erb
+++ b/app/views/flats/index.html.erb
@@ -10,7 +10,7 @@
     <% @flats.each do |flat| %>
       <% x += 1 %>
       <%= link_to flat_path(flat) do %>
-        <div class="card-flat text-center p-2 m-3 bd-highlight" style="width: 24rem;">
+        <div class="card-flat text-center p-2 m-3 bd-highlight" style="width: 18rem;">
           <!--Philipp added the line below to display a cloudinary image instead of an image from a url: -->
           <% if flat.photo.attached? %>
             <%= cl_image_tag flat.photo.key, crop: :fill %>
@@ -25,11 +25,12 @@
         </div>
       <% end %>
     <% end %>
+  </div>
 
-    <div style="width: 100%; height: 500px;"
+    <div id = "map" style="width: 100%; height: 500px; position: sticky; top: 0;"
       data-controller="map"
       data-map-markers-value="<%= @markers.to_json %>"
       data-map-api-key-value="<%= ENV['MAPBOX_API_KEY'] %>">
     </div>
-  </div>
+  <!--</div>-->
 </div>


### PR DESCRIPTION
Customized the index page by panning the flats left and the map right. Map now sticks to the page as you scroll down or up.